### PR TITLE
Added feature to set naming patterns for columns and offsets

### DIFF
--- a/examples/input.scss
+++ b/examples/input.scss
@@ -6,6 +6,12 @@
 	gutter-on-outside: true;
 	gutter: 30px;
 	name: mesh;
+	naming_column_single: |NAME|-col;
+	naming_column_column: |NAME|-col-|COLUMN|;
+	naming_column_mq: |NAME|-col-|MQ|-|COLUMN|;
+	naming_offset_single: |NAME|-off;
+	naming_offset_column: |NAME|-off-|COLUMN|;
+	naming_offset_mq: |NAME|-off-|MQ|-|COLUMN|;
 	query-condition: min-width;
 	responsive-gutter: false;
 

--- a/index.js
+++ b/index.js
@@ -121,12 +121,12 @@ function getPropValue(component, property) {
 					let fac = 1 / percentage;
 					value = settings.gutterOnOutside
 						? getGutterValue(
-								property,
-								settings.calcedContainerWidth / fac - settings.gutter * 2
+							property,
+							settings.calcedContainerWidth / fac - settings.gutter * 2
 						  )
 						: getGutterValue(
-								property,
-								(settings.calcedContainerWidth + settings.gutter * 2) / fac -
+							property,
+							(settings.calcedContainerWidth + settings.gutter * 2) / fac -
 									settings.gutter * 2
 						  );
 					value = value.substring(0, value.length - 1);
@@ -141,8 +141,8 @@ function getPropValue(component, property) {
 					if (property.name.indexOf("margin") >= 0) {
 						value = settings.gutterOnOutside
 							? getGutterValue(
-									property,
-									settings.calcedContainerWidth - settings.gutter * 2
+								property,
+								settings.calcedContainerWidth - settings.gutter * 2
 							  )
 							: getGutterValue(property, settings.calcedContainerWidth);
 						value = `-${value}`;
@@ -162,8 +162,8 @@ function getPropValue(component, property) {
 				value = settings.gutterOnOutside
 					? getGutterValue(property, settings.calcedContainerWidth)
 					: getGutterValue(
-							property,
-							settings.calcedContainerWidth + settings.gutter * 2
+						property,
+						settings.calcedContainerWidth + settings.gutter * 2
 					  );
 				break;
 			case "column:nested":
@@ -173,8 +173,8 @@ function getPropValue(component, property) {
 					value = settings.gutterOnOutside
 						? getGutterValue(property, settings.calcedContainerWidth / fac)
 						: getGutterValue(
-								property,
-								(settings.calcedContainerWidth + settings.gutter * 2) / fac
+							property,
+							(settings.calcedContainerWidth + settings.gutter * 2) / fac
 						  );
 					value = value.substring(0, value.length - 1);
 					value = `0 ${value}${settings.gutterUnit}`;
@@ -211,8 +211,8 @@ function getPropValue(component, property) {
 						value = settings.gutterOnOutside
 							? getGutterValue(property, settings.calcedContainerWidth)
 							: getGutterValue(
-									property,
-									settings.calcedContainerWidth + settings.gutter * 2
+								property,
+								settings.calcedContainerWidth + settings.gutter * 2
 							  );
 					} else {
 						defaultValue();

--- a/index.js
+++ b/index.js
@@ -71,6 +71,21 @@ function updateSettings(obj) {
 
 	// columnSingleWidth
 	settings.columnSingleWidth = 100 / settings.columnCount;
+
+	const namingProps = [
+		"column_single",
+		"column_column",
+		"column_mq",
+		"offset_single",
+		"offset_column",
+		"offset_mq",
+	];
+
+	for(let i = 0; i < namingProps.length; i++){
+		const namingProp = `naming_${namingProps[i]}`;
+		if (namingProp in obj)
+			settings[namingProp] = obj[namingProp];
+	}
 }
 
 function updateColumnWidth(fac) {
@@ -257,6 +272,30 @@ function getComponentRules(viewport, options) {
 	return rule;
 }
 
+function getSelectorByNamePattern(type,data){
+	const haveMQ = data.mq != null;
+	const haveColumn = data.column != null;
+	let pattern;
+	switch(true){
+		case haveMQ : {
+			pattern = settings[`naming_${type}_mq`];
+			break;
+		}
+		case haveColumn : {
+			pattern = settings[`naming_${type}_column`];
+			break;
+		}
+		default :{
+			pattern = settings[`naming_${type}_single`];
+		}
+	}
+	const selector = pattern.replace(/\|NAME\|/gm,data.name)
+		.replace(/\|COLUMN\|/gm,data.column)
+		.replace(/\|MQ\|/gm,data.mq);
+
+	return selector;
+}
+
 function getRules(grid) {
 	updateSettings(grid);
 	const rules = [];
@@ -285,7 +324,7 @@ function getRules(grid) {
 		// column-basic
 		getComponentRules(grid, {
 			component: "column-basic",
-			selector: `[class*="${settings.name}-column"]`
+			selector: `[class*="${getSelectorByNamePattern("column",{name:settings.name})}"]`
 		})
 	);
 
@@ -307,20 +346,18 @@ function getRules(grid) {
 				// column
 				getComponentRules(grid, {
 					component: "column",
-					selector: `.${settings.name}-column-${i}`
+					selector: `.${getSelectorByNamePattern("column",{name:settings.name,column:i})}`
 				}),
 				// column-x column
 				getComponentRules(grid, {
 					component: "column:nested",
-					selector: `[class*="${settings.name}-column-${i}"] [class*="${
-						settings.name
-					}-column"]`,
+					selector: `[class*="${getSelectorByNamePattern("column",{name:settings.name,column:i})}"] [class*="${getSelectorByNamePattern("column",{name:settings.name})}"]`,
 					index: i
 				}),
 				// column-x void
 				getComponentRules(grid, {
 					component: "void:nested",
-					selector: `[class*="${settings.name}-column-${i}"] .${
+					selector: `[class*="${getSelectorByNamePattern("column",{name:settings.name,column:i})}"] .${
 						settings.name
 					}-void`,
 					index: i
@@ -342,7 +379,7 @@ function getRules(grid) {
 			// offset
 			getComponentRules(grid, {
 				component: "offset",
-				selector: `.${settings.name}-offset-${i}`
+				selector: `.${getSelectorByNamePattern("offset",{name:settings.name,column:i})}`
 			})
 		);
 	}
@@ -378,22 +415,18 @@ function getRules(grid) {
 					// column
 					getComponentRules(curViewport, {
 						component: "column",
-						selector: `.${settings.name}-column-${settings.viewportName}-${i}`
+						selector: `.${getSelectorByNamePattern("column",{name:settings.name,column:i,mq:settings.viewportName})}`
 					}),
 					// column-x column
 					getComponentRules(grid, {
 						component: "column:nested",
-						selector: `[class*="${settings.name}-column-${
-							settings.viewportName
-						}-${i}"] [class*="${settings.name}-column"]`,
+						selector: `[class*="${getSelectorByNamePattern("column",{name:settings.name,column:i,mq:settings.viewportName})}"] [class*="${settings.name}-column"]`,
 						index: i
 					}),
 					// column-x void
 					getComponentRules(grid, {
 						component: "void:nested",
-						selector: `[class*="${settings.name}-column-${
-							settings.viewportName
-						}-${i}"] .${settings.name}-void`,
+						selector: `[class*="${getSelectorByNamePattern("column",{name:settings.name,column:i,mq:settings.viewportName})}"] .${settings.name}-void`,
 						index: i
 					})
 				);
@@ -413,7 +446,7 @@ function getRules(grid) {
 				// offset
 				getComponentRules(curViewport, {
 					component: "offset",
-					selector: `.${settings.name}-offset-${settings.viewportName}-${i}`
+					selector: `.${getSelectorByNamePattern("offset",{name:settings.name,column:i,mq:settings.viewportName})}`
 				})
 			);
 		}

--- a/index.js
+++ b/index.js
@@ -123,12 +123,12 @@ function getPropValue(component, property) {
 						? getGutterValue(
 							property,
 							settings.calcedContainerWidth / fac - settings.gutter * 2
-						  )
+						)
 						: getGutterValue(
 							property,
 							(settings.calcedContainerWidth + settings.gutter * 2) / fac -
 									settings.gutter * 2
-						  );
+						);
 					value = value.substring(0, value.length - 1);
 					value = `0 -${value}${settings.gutterUnit}`;
 					value = settings.responsiveGutter
@@ -143,7 +143,7 @@ function getPropValue(component, property) {
 							? getGutterValue(
 								property,
 								settings.calcedContainerWidth - settings.gutter * 2
-							  )
+							)
 							: getGutterValue(property, settings.calcedContainerWidth);
 						value = `-${value}`;
 					} else if (
@@ -164,7 +164,7 @@ function getPropValue(component, property) {
 					: getGutterValue(
 						property,
 						settings.calcedContainerWidth + settings.gutter * 2
-					  );
+					);
 				break;
 			case "column:nested":
 				{
@@ -175,7 +175,7 @@ function getPropValue(component, property) {
 						: getGutterValue(
 							property,
 							(settings.calcedContainerWidth + settings.gutter * 2) / fac
-						  );
+						);
 					value = value.substring(0, value.length - 1);
 					value = `0 ${value}${settings.gutterUnit}`;
 					value = settings.responsiveGutter
@@ -213,7 +213,7 @@ function getPropValue(component, property) {
 							: getGutterValue(
 								property,
 								settings.calcedContainerWidth + settings.gutter * 2
-							  );
+							);
 					} else {
 						defaultValue();
 					}

--- a/lib/settings.json
+++ b/lib/settings.json
@@ -12,6 +12,12 @@
 	"gutter": 15,
 	"gutterUnit": "px",
 	"name": "mesh",
+	"naming_column_single": "|NAME|-column",
+	"naming_column_column": "|NAME|-column-|COLUMN|",
+	"naming_column_mq": "|NAME|-column-|MQ|-|COLUMN|",
+	"naming_offset_single": "|NAME|-offset",
+	"naming_offset_column": "|NAME|-offset-|COLUMN|",
+	"naming_offset_mq": "|NAME|-offset-|MQ|-|COLUMN|",
 	"queryCondition": {
 		"value": "min-width",
 		"options": ["min-width", "max-width"]

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,11 +1,11 @@
 const fs = require("fs");
 
 const settings = ctx => ({
-  parser: "postcss-scss",
-  map: ctx.options.map,
-  plugins: {
-    "postcss-mesh": {}
-  }
+	parser: "postcss-scss",
+	map: ctx.options.map,
+	plugins: {
+		"postcss-mesh": {}
+	}
 });
 
 module.exports = settings;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,3 @@
-const fs = require("fs");
-
 const settings = ctx => ({
 	parser: "postcss-scss",
 	map: ctx.options.map,

--- a/utils/getInlineSettings.js
+++ b/utils/getInlineSettings.js
@@ -51,10 +51,10 @@ module.exports = function(input) {
 		tempSortedViewports =
 			currentGrid["query-condition"] === "min-width"
 				? tempSortedViewports.sort(function(a, b) {
-						return a - b;
+					return a - b;
 				  })
 				: tempSortedViewports.sort(function(a, b) {
-						return b - a;
+					return b - a;
 				  });
 
 		for (let i = 0; i < tempSortedViewports.length; i++) {


### PR DESCRIPTION
Default config is:
```
"naming_column_single": "|NAME|-column",
"naming_column_column": "|NAME|-column-|COLUMN|",
"naming_column_mq": "|NAME|-column-|MQ|-|COLUMN|",
"naming_offset_single": "|NAME|-offset",
"naming_offset_column": "|NAME|-offset-|COLUMN|",
"naming_offset_mq": "|NAME|-offset-|MQ|-|COLUMN|",
```

A warning should be added to the documentation that it have to be handle with care to not use too short like `naming_column_single: c`this generates dangerous selector which selects every element with a class wich contains a `c`. So the name prefix (or suffix) should always be present.